### PR TITLE
Fix for ZODB commit on view

### DIFF
--- a/redomino/tokenrole/tokenroleprovider.py
+++ b/redomino/tokenrole/tokenroleprovider.py
@@ -38,14 +38,11 @@ class TokenRolesAnnotateAdapter(object):
     def __init__(self, context):
         self.annotations = IAnnotations(context).setdefault(ANNOTATIONS_KEY,
                                                            PersistentDict())
-    
+
     @apply
     def token_dict():
         def get(self):
-            token_dict = self.annotations.get('token_dict', None)
-            if not token_dict:
-                token_dict = self.annotations['token_dict'] = PersistentDict()
-            return token_dict
+            return self.annotations.get('token_dict', {})
         def set(self, value):
             self.annotations['token_dict'] = value
         return property(get, set)
@@ -58,6 +55,12 @@ class TokenInfoSchema(object):
     def __init__(self, context):
         self.context = context
         self.annotation = ITokenRolesAnnotate(self.context)
+
+    def setter(self, name, value):
+        if not self.annotation.token_dict:
+            self.annotation.token_dict = PersistentDict()
+        token_id = self.annotation.token_dict.setdefault(self.token_id, PersistentDict())
+        token_id[name] = value
 
     @apply
     def token_id():
@@ -72,9 +75,7 @@ class TokenInfoSchema(object):
         def getter(self):
             return self.annotation.token_dict.get(self.token_id, {}).get('token_end')
         def setter(self, value):
-            if not self.token_id in self.annotation.token_dict:
-                self.annotation.token_dict[self.token_id] = PersistentDict()
-            self.annotation.token_dict[self.token_id]['token_end'] = value
+            self.setter('token_end', value)
         return property(getter, setter)
 
     @apply
@@ -82,9 +83,7 @@ class TokenInfoSchema(object):
         def getter(self):
             return self.annotation.token_dict.get(self.token_id, {}).get('token_roles')
         def setter(self, value):
-            if not self.token_id in self.annotation.token_dict:
-                self.annotation.token_dict[self.token_id] = PersistentDict()
-            self.annotation.token_dict[self.token_id]['token_roles'] = value
+            self.setter('token_roles', value)
         return property(getter, setter)
 
         


### PR DESCRIPTION
Currently, line #47 creates a database transaction on view for any logged in Plone user as it writes a PersistentDict into the annotations, this is done on every view as the check "if not token_dict" also applies for an empty PersistentDict. This is of course sub-optimal as it can lead to large database sizes and slowdowns.

The patch solves this by not writing the PersistentDict. Instead, the setter functions create it if necessary.