### PR TITLE
Quote url path when setting cookie

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Quote url path when setting cookie
+  [instification]
 
 
 1.0 (2018-04-16)

--- a/redomino/tokenrole/tokenroleprovider.py
+++ b/redomino/tokenrole/tokenroleprovider.py
@@ -119,8 +119,7 @@ class TokenRolesLocalRolesProviderAdapter(object):
             if expire_date.replace(tzinfo=None) > datetime.now():
                 if token not in request.cookies:
                     physical_path = self.context.getPhysicalPath()
-                    # Is there a better method for calculate the url_path?
-                    url_path = '/' + '/'.join(request.physicalPathToVirtualPath(physical_path))
+                    url_path = urllib.quote('/' + '/'.join(request.physicalPathToVirtualPath(physical_path)))
                     response.setCookie(name='token',
                                        value=token,
                                        expires=DateTime(expire_date).toZone('GMT').rfc822(),


### PR DESCRIPTION
This replaces #7 which I have now rebased and updated. Cookies were being set incorrectly when they contained characters that should be quoted.