### PR TITLE
Use quote from six.moves.urllib.parse since six.moves.urllib has no attribute/function quote.

### DIFF
--- a/redomino/tokenrole/tokenroleprovider.py
+++ b/redomino/tokenrole/tokenroleprovider.py
@@ -121,7 +121,7 @@ class TokenRolesLocalRolesProviderAdapter(object):
             if expire_date.replace(tzinfo=None) > datetime.now():
                 if token not in request.cookies:
                     physical_path = self.context.getPhysicalPath()
-                    url_path = urllib.quote('/' + '/'.join(request.physicalPathToVirtualPath(physical_path)))
+                    url_path = urllib.parse.quote('/' + '/'.join(request.physicalPathToVirtualPath(physical_path)))
                     response.setCookie(name='token',
                                        value=token,
                                        expires=DateTime(expire_date).toZone('GMT').rfc822(),


### PR DESCRIPTION
I noticed that it's not possible to access a page with the token-URL because you get the following error message.

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 156, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 338, in publish_module
  Module ZPublisher.WSGIPublisher, line 244, in publish
  Module ZPublisher.BaseRequest, line 627, in traverse
  Module Products.PluggableAuthService.PluggableAuthService, line 263, in validate
  Module Products.PluggableAuthService.PluggableAuthService, line 826, in _authorizeUser
  Module Products.PlonePAS.plugins.ufactory, line 192, in allowed
  Module plone.memoize.volatile, line 73, in replacement
  Module borg.localrole.workspace, line 476, in checkLocalRolesAllowed
  Module redomino.tokenrole.tokenroleprovider, line 124, in getRoles
AttributeError: module 'six.moves.urllib' has no attribute 'quote'
```

Since this is part of the migration to Python3 (with Plone5.2) I suggest merging it into the plone52-Branch.

Would you mind reviewing my change @tomgross ?